### PR TITLE
BUG(4): Fix dropping within playlist after last entry

### DIFF
--- a/src/components/playlist/playlist_view.vala
+++ b/src/components/playlist/playlist_view.vala
@@ -531,9 +531,10 @@ namespace Abraca {
 				}
 
 				dest = dst;
-				return true;
+			} else {
+				dest = model.iter_n_children (null);
 			}
-			return false;
+			return true;
 		}
 
 		/**


### PR DESCRIPTION
Dropping mediaids was already fine, as those are just get added (instead of
inserted) if the position can't be found. Having said that it might be better
to do that here too? Or to remove that special case there?

fixes #4
