### PR TITLE
OTHER: Gdk.Pixbuf.from_inline no longer takes length

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,7 @@ env.VariantDir('build', '.')
 env.Append(VALAPKGPATH = ['vapi'])
 
 conf = env.Configure('build/build-config.h')
-conf.CheckVala('0.11.5')
+conf.CheckVala('0.16.0')
 conf.CheckCCompiler()
 conf.CheckPkgConfig()
 conf.CheckApp('msgfmt')

--- a/src/main_window.vala
+++ b/src/main_window.vala
@@ -34,7 +34,7 @@ namespace Abraca {
 			create_widgets(client);
 
 			try {
-				set_icon(new Gdk.Pixbuf.from_inline (-1, Resources.abraca_32, false));
+				set_icon(new Gdk.Pixbuf.from_inline (Resources.abraca_32, false));
 			} catch (GLib.Error e) {
 				GLib.assert_not_reached ();
 			}
@@ -301,7 +301,7 @@ namespace Abraca {
 				var about = about_builder.get_object("abraca_about") as Gtk.AboutDialog;
 
 				try {
-					about.set_logo(new Gdk.Pixbuf.from_inline (-1, Resources.abraca_192, false));
+					about.set_logo(new Gdk.Pixbuf.from_inline (Resources.abraca_192, false));
 				} catch (GLib.Error e) {
 					GLib.assert_not_reached ();
 				}

--- a/src/stock.vala
+++ b/src/stock.vala
@@ -34,7 +34,7 @@ namespace Abraca {
 		set = new Gtk.IconSet();
 
 		source = new Gtk.IconSource();
-		source.set_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_equalizer, false));
+		source.set_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_equalizer, false));
 		set.add_source(source);
 
 		factory.add(STOCK_EQUALIZER, set);
@@ -44,11 +44,11 @@ namespace Abraca {
 		set = new Gtk.IconSet();
 
 		source = new Gtk.IconSource();
-		source.set_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_collection_24,  false));
+		source.set_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_collection_24,  false));
 		set.add_source(source);
 
 		source = new Gtk.IconSource();
-		source.set_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_collection_16,  false));
+		source.set_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_collection_16,  false));
 		source.set_size(Gtk.IconSize.MENU);
 		source.set_size_wildcarded(false);
 		set.add_source(source);
@@ -60,11 +60,11 @@ namespace Abraca {
 		set = new Gtk.IconSet();
 
 		source = new Gtk.IconSource();
-		source.set_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_playlist_24,  false));
+		source.set_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_playlist_24,  false));
 		set.add_source(source);
 
 		source = new Gtk.IconSource();
-		source.set_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_playlist_16,  false));
+		source.set_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_playlist_16,  false));
 		source.set_size(Gtk.IconSize.MENU);
 		source.set_size_wildcarded(false);
 		set.add_source(source);
@@ -73,9 +73,9 @@ namespace Abraca {
 
 		/* Other icons */
 
-		factory.add(STOCK_RATED,    new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_rating_rated,   false)));
-		factory.add(STOCK_UNRATED,  new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_rating_unrated, false)));
-		factory.add(STOCK_FAVORITE, new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(-1, Resources.abraca_favorite,       false)));
+		factory.add(STOCK_RATED,    new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_rating_rated,   false)));
+		factory.add(STOCK_UNRATED,  new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_rating_unrated, false)));
+		factory.add(STOCK_FAVORITE, new Gtk.IconSet.from_pixbuf(new Gdk.Pixbuf.from_inline(Resources.abraca_favorite,       false)));
 
 		return factory;
 	}


### PR DESCRIPTION
In vala 0.16.0, Gdk.Pixbuf.from_inline no longer takes an argument specifying the length of the array.
