### PR TITLE
OTHER: build script to not check for vala twice

### DIFF
--- a/wscript
+++ b/wscript
@@ -12,9 +12,9 @@ def options(opt):
 	opt.load('compiler_c vala intltool')
 
 def configure(conf):
-	conf.load('compiler_c vala intltool')
+	conf.load('compiler_c intltool')
 	conf.load('gresource man about-generator', tooldir='waftools')
-
+	conf.load('vala', funs='')
 	conf.check_vala((0, 24, 0))
 
 	if 'CFLAGS' not in os.environ:


### PR DESCRIPTION
Hi, as discussed on IRC, here's a patch so that the configure doesn't fail when valac-0.8 is not there.