### PR TITLE
add expected VALAFLAGS

### DIFF
--- a/wscript
+++ b/wscript
@@ -12,7 +12,7 @@ def options(opt):
 	opt.load('compiler_c vala intltool')
 
 def configure(conf):
-	conf.load('compiler_c intltool')
+	conf.load('gnu_dirs compiler_c intltool')
 	conf.load('gresource man about-generator', tooldir='waftools')
 	conf.load('vala', funs='')
 	conf.check_vala((0, 24, 0))

--- a/wscript
+++ b/wscript
@@ -16,6 +16,7 @@ def configure(conf):
 	conf.load('gresource man about-generator', tooldir='waftools')
 	conf.load('vala', funs='')
 	conf.check_vala((0, 24, 0))
+	conf.env.VALAFLAGS = ['-C', '--quiet']
 
 	if 'CFLAGS' not in os.environ:
 		conf.env.append_unique("CFLAGS", ["-g", "-O0", "-fdiagnostics-show-option"])


### PR DESCRIPTION
Commit d7cf3fa, introduced by pull request #30 breaks compilation for me. I found this to be because `valac` compiles to byte code by default. Setting the `-C` flag restores the behaviour expected by the Vala waftool. This is normally done automatically by its configure function, which is skipped since the mentioned commit. Specifying the flag manually thereafter restores compilation.