### PR TITLE
Reproducibility fix to remove the timestamp metadata

### DIFF
--- a/waftools/man.py
+++ b/waftools/man.py
@@ -14,7 +14,7 @@ def gzip_func(task):
     try:
         input = open(infile, 'rb')
         outf = open(outfile, 'wb')
-        output = gzip.GzipFile(os.path.basename(infile), fileobj=outf)
+        output = gzip.GzipFile(os.path.basename(infile), fileobj=outf, mtime=0)
         output.write(input.read())
     finally:
         if input:


### PR DESCRIPTION
The build has been made reproducible by removing the timestamp information from gzip metadata. Please see the below url to know more about reproducible-builds project.
https://wiki.debian.org/ReproducibleBuilds